### PR TITLE
Extract relativeNumbers from cldr-numbers-full

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const expandLocales = require('./lib/expand-locales');
 const extractPluralRules = require('./lib/extract-plurals');
 const getAllLocales = require('./lib/locales').getAllLocales;
 const extractRelativeFields = require('./lib/extract-relative');
+const extractRelativeNumbers = require('./lib/extract-numbers');
 
 function mergeData(/*...sources*/) {
     let sources = [].slice.call(arguments);
@@ -27,6 +28,7 @@ function extractData(options) {
         locales       : null,
         pluralRules   : false,
         relativeFields: false,
+        relativeNumbers: false,
     }, options);
 
     // Default to all CLDR locales if none have been provided.
@@ -38,7 +40,8 @@ function extractData(options) {
     const output = mergeData(
         expandLocales(locales),
         options.pluralRules && extractPluralRules(locales),
-        options.relativeFields && extractRelativeFields(locales)
+        options.relativeFields && extractRelativeFields(locales),
+        options.relativeNumbers && extractRelativeNumbers(locales)
     );
 
     return output;

--- a/lib/extract-numbers.js
+++ b/lib/extract-numbers.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var p = require('path');
+
+var getParentLocale = require('./locales').getParentLocale;
+var hasNumberFields   = require('./locales').hasNumberFields;
+var normalizeLocale = require('./locales').normalizeLocale;
+
+// The set of CLDR date field names that are used in FormatJS.
+var NUMBER_FIELD_NAMES = [
+    'decimalFormats-numberSystem-latn',
+    'currencyFormats-numberSystem-latn',
+];
+
+module.exports = function extractNumberFields(locales) {
+    // The CLDR states that the "root" locale's data should be used to fill in
+    // any missing data as its data is the default.
+    var defaultFields = loadNumberFields('root');
+
+    var fields = {};
+    var hashes = {};
+
+    // Loads and caches the relative fields for a given `locale` because loading
+    // and transforming the data is expensive.
+    function getNumberFields(locale) {
+        var relativeFields = fields[locale];
+        if (relativeFields) {
+            return relativeFields;
+        }
+
+        if (hasNumberFields(locale)) {
+            relativeFields = fields[locale] = loadNumberFields(locale);
+            return relativeFields;
+        }
+    }
+
+    // Hashes and caches the `fields` for a given `locale` to avoid hashing more
+    // than once since it could be expensive.
+    function hashFields(locale, fields) {
+        var hash = hashes[locale];
+        if (hash) {
+            return hash;
+        }
+
+        hash = hashes[locale] = JSON.stringify(fields);
+        return hash;
+    }
+
+    // We want to de-dup data that can be referenced from upstream in the
+    // `locale`'s hierarchy when that locale's relative fields are the _exact_
+    // same as one of its ancestors. This will traverse the hierarchy for the
+    // given `locale` until it finds an ancestor with same same relative fields.
+    // When an ancestor can't be found, a data entry must be created for the
+    // `locale` since its relative fields are unique.
+    function findGreatestAncestor(locale) {
+        // The "root" locale is not a suitable ancestor, because there won't be
+        // an entry for "root" in the final data object.
+        var parentLocale = getParentLocale(locale);
+        if (!parentLocale || parentLocale === 'root') {
+            return locale;
+        }
+
+        // When the `locale` doesn't have fields data, we need to traverse up
+        // its hierarchy to find suitable relative fields data.
+        if (!hasNumberFields(locale)) {
+            return findGreatestAncestor(parentLocale);
+        }
+
+        var fields;
+        var parentFields;
+        if (hasNumberFields(parentLocale)) {
+            fields       = getNumberFields(locale);
+            parentFields = getNumberFields(parentLocale);
+
+            // We can only use this ancestor's fields if they hash to the
+            // _exact_ same value as `locale`'s fields. If the ancestor is
+            // suitable, we keep looking up its hierarchy until the relative
+            // fields are determined to be unique.
+            if (hashFields(locale, fields) ===
+                hashFields(parentLocale, parentFields)) {
+
+                return findGreatestAncestor(parentLocale);
+            }
+        }
+
+        return locale;
+    }
+
+    return locales.reduce(function (numberFields, locale) {
+        // Walk the `locale`'s hierarchy to look for suitable ancestor with the
+        // _exact_ same relative fields. If no ancestor is found, the given
+        // `locale` will be returned.
+        locale = findGreatestAncestor(normalizeLocale(locale));
+
+        // The "root" locale is ignored because the built-in `Intl` libraries in
+        // JavaScript have no notion of a "root" locale; instead they use the
+        // IANA Language Subtag Registry.
+        if (locale === 'root') {
+            return numberFields;
+        }
+
+        // Add an entry for the `locale`, which might be an ancestor. If the
+        // locale doesn't have relative fields, then we fallback to the "root"
+        // locale's fields.
+        numberFields[locale] = {
+            numbers: getNumberFields(locale) || defaultFields,
+        };
+
+        return numberFields;
+    }, {});
+};
+
+function loadNumberFields(locale) {
+    var locale   = normalizeLocale(locale);
+    var filename = p.join('cldr-numbers-full', 'main', locale, 'numbers.json');
+    var fields   = require(filename).main[locale].numbers;
+    // Reduce the number fields data down to whitelist of fields needed in the
+    // FormatJS libs.
+    return NUMBER_FIELD_NAMES.reduce(function (relative, field) {
+        relative[field] = fields[field];
+        return relative;
+    }, {});
+}

--- a/lib/locales.js
+++ b/lib/locales.js
@@ -11,6 +11,7 @@ var glob = require('glob');
 exports.getAllLocales   = getAllLocales;
 exports.getParentLocale = getParentLocale;
 exports.hasDateFields   = hasDateFields;
+exports.hasNumberFields   = hasNumberFields;
 exports.hasPluralRule   = hasPluralRule;
 exports.normalizeLocale = normalizeLocale;
 
@@ -32,6 +33,16 @@ var DATE_FIELDS_LOCALES_HASH = glob.sync('*/dateFields.json', {
     return hash;
 }, {});
 
+var NUMBERS_LOCALES_HASH = glob.sync('*/numbers.json', {
+    cwd: p.resolve(
+        p.dirname(require.resolve('cldr-numbers-full/package.json')),
+        './main'
+    ),
+}).reduce(function (hash, filename) {
+    hash[p.dirname(filename)] = true;
+    return hash;
+}, {});
+
 // Some locales that have a `pluralRuleFunction` don't have a `dateFields.json`
 // file, and visa versa, so this creates a unique collection of all locales in
 // the CLDR for which we need data from.
@@ -39,6 +50,7 @@ var ALL_LOCALES_HASH =
     Object.keys(PARENT_LOCALES_HASH)
     .concat(Object.keys(PLURAL_LOCALES_HASH))
     .concat(Object.keys(DATE_FIELDS_LOCALES_HASH))
+    .concat(Object.keys(NUMBERS_LOCALES_HASH))
     .map(function (locale) {
         if (locale === 'en-US-POSIX') {
             return 'en-US';
@@ -87,6 +99,10 @@ function getParentLocale(locale) {
 
 function hasDateFields(locale) {
     return DATE_FIELDS_LOCALES_HASH.hasOwnProperty(normalizeLocale(locale));
+}
+
+function hasNumberFields(locale) {
+    return NUMBERS_LOCALES_HASH.hasOwnProperty(normalizeLocale(locale));
 }
 
 function hasPluralRule(locale) {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -212,6 +212,18 @@ describe('extractData()', function () {
                 expect(data.en.fields).to.be.an('object');
             });
         });
+
+        describe('relativeNumbers', function () {
+            it('should contribute a `numbers` object property', function () {
+                var data = extractData({
+                    locales       : ['en'],
+                    relativeNumbers: true,
+                });
+
+                expect(data.en).to.have.key('numbers');
+                expect(data.en.numbers).to.be.an('object');
+            });
+        });
     });
 
     describe('Locale hierarchy', function () {


### PR DESCRIPTION
WIP - need to add more tests + refactor some methods (i.e. `findGreatestAncestor`) but basic structure is there.

A few thoughts/questions before I finish this PR...

1.  With the addition of relativeNumbers, `relativeFields` sounds redundant or perhaps not too specific.
2. We are generating all locales by merging in the locales from the dates && numbers cldr package.  Seems redundant, but perhaps desire is to be "safe"?
3.  Does `relativeNumbers` sound like a correct variable name to you? 